### PR TITLE
[FIX] WikisController#index authorization rules

### DIFF
--- a/app/models/wiki.rb
+++ b/app/models/wiki.rb
@@ -1,5 +1,7 @@
 class Wiki < ActiveRecord::Base
   belongs_to :user
   has_many :collaborators
+
+  default_scope { order('created_at DESC') }
   scope :visible_to, ->(user, viewable = true) { user ? all : where(public: viewable) }
 end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -11,26 +11,49 @@ class WikiPolicy < ApplicationPolicy
       @scope = scope
     end
 
+    # Note: Although Rails 3 & 4 provide "merge" to mix several scopes:
+    #
+    #   # Just an example--imagine the "public" and "owned_by" scopes exist:
+    #   Wiki.public.merge(Wiki.owned_by(User.last))
+    #
+    # it does an AND:
+    #
+    #   Wiki.public.merge(Wiki.owned_by(User.last)).to_sql
+    #     User Load (0.3ms)  SELECT  "users".* FROM "users"  ORDER BY "users"."id" DESC LIMIT 1
+    #     => SELECT "wikis".* FROM "wikis" WHERE "wikis"."public" = 't' AND "wikis"."user_id" = 7
+    #
+    # We would like to an OR instead. This is not possible… yet.
+    #
+    # Rails 5 will support mixing several scopes with OR:
+    #
+    #   @see https://github.com/rails/rails/pull/16052
+    #   @see https://github.com/rails/rails/commit/9e42cf019f2417473e7dcbfcb885709fa2709f89
+    #
+    # In the meantime, we will need to use a trick, stepping one level down in
+    # the abstraction stack: using Arel (https://github.com/rails/arel).
     def resolve
-      wikis = []
-      if user.present? && user.role == 'admin'
+      # 0. Anonymous users don't see blah.
+      return scope.none unless user.present?
+
+      wiki = Wiki.arel_table
+
+      # 1. User is an admin, sees all wikis.
+      if user.admin?
         wikis = scope.all
-      elsif user.present? && user.role == 'premium'
-        all_wikis = scope.all
-        all_wikis.each do |wiki|
-          if wiki.public? || wiki.user == user || wiki.user.include?(user)
-            wikis << wiki
-          end
-        end
+
+      # 2. User has a premium account, sees public wikis, own wikis and
+      # private wikis he's been invited to.
+      elsif user.premium?
+        #wikis = scope.publ.or(scope.owned_by(user)).or(scope.invited_as(user)) # NOT POSSIBLE YET (RAILS 5 ONLY)
+        # FIXME: need to add the .or for private wikis user is a collaborator on.
+        wikis = Wiki.where(wiki[:public].eq('t').or(wiki[:user_id].eq(user.id)))
+
+      # 3. User has default access, sees publics wikis and own wikis.
       else
-        all_wikis = scope.all
-        wikis = []
-        all_wikis.each do |wiki|
-          if wiki.public? || wiki.users.include?(user)
-            wikis << wiki
-          end
-        end
+        #wikis = scope.publ.or(scope.owned_by(user)) # NOT POSSIBLE YET (RAILS 5 ONLY)
+        wikis = Wiki.where(wiki[:public].eq('t').or(wiki[:user_id].eq(user.id)))
       end
+
       wikis
     end
   end


### PR DESCRIPTION
Hey,

I tried to fix something I overlooked in Blocipedia: the list of wikis accessible to a given user.

Depending on the user's role (standard *vs* premium *vs* admin), he should not see the same thing. Easy to say, quite tricky to do, due some limitations with Rails' ActiveRecord (but things will change with Rails 5). I tried to provide some valuable insights as comments in the code, so you can understand why I did things the way I did. Feel free to ask me questions about it though.

I also added a default scope to display the newest wikis first.