### PR TITLE
[FIX] Only premium users can create private wikis

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -51,12 +51,8 @@ class ApplicationPolicy
     record.class
   end
 
-  def make_private?
-    destroy?
-  end
-
   # --------------------------- Utility methods --------------------------------
-  
+
   def record_exists?
     scope.where(:id => record.id).exists?
   end

--- a/app/policies/wiki_policy.rb
+++ b/app/policies/wiki_policy.rb
@@ -3,6 +3,10 @@ class WikiPolicy < ApplicationPolicy
     record.public? || user.present?
   end
 
+  def make_private?
+    user_is?('premium', 'admin')
+  end
+
   class Scope
     attr_reader :user, :scope
 

--- a/app/views/wikis/new.html.erb
+++ b/app/views/wikis/new.html.erb
@@ -8,7 +8,7 @@
   <%= f.label :body %>
   <%= f.text_area :body, rows: 8, class: 'form-control', placeholder: 'Enter Wiki body'%>
 </div>
-<% if current_user.premium? %>
+<% if policy(@wiki).make_private? %>
 <div class='form-group'>
   <%= f.label :public, class: 'checkbox' do %>
     <%= f.check_box :public %> Public wiki


### PR DESCRIPTION
Hey,

Following [the user story](https://www.bloc.io/users/umar-khokhar/checkpoints/1045), only premium users should be able to create private wikis. It's something that wasn't quite true in the latest version of the code.

Here's my proposal to fix that. Please review and tell me what you think :) Basically, I:

* moved the `make_private?` policy to the `WikiPolicy`, cause I think it belongs here
* used that policy everywhere
* included the admin users alongside premium users, cause I think admins should be able to do everything